### PR TITLE
Support Alpine 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 RUN apk --no-cache add alpine-sdk coreutils cmake \
   && adduser -G abuild -g "Alpine Package Builder" -s /bin/ash -D builder \
   && echo "builder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \


### PR DESCRIPTION
💁 Alpine Linux version 3.9.0 was released in January 2019.

https://www.alpinelinux.org/posts/Alpine-3.9.0-released.html