### PR TITLE
Support Alpine v3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.12
 RUN apk --no-cache add alpine-sdk coreutils cmake \
   && adduser -G abuild -g "Alpine Package Builder" -s /bin/ash -D builder \
   && echo "builder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \


### PR DESCRIPTION
💁 Alpine Linux version 3.12 was [released on 2020-05-29](https://alpinelinux.org/posts/Alpine-3.12.0-released.html).