### PR TITLE
Sudo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.12
-RUN apk --no-cache add alpine-sdk coreutils cmake \
+RUN apk --no-cache add alpine-sdk coreutils cmake sudo \
   && adduser -G abuild -g "Alpine Package Builder" -s /bin/ash -D builder \
   && echo "builder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
   && mkdir /packages \

--- a/edge/Dockerfile
+++ b/edge/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:edge
 RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories \
-  && apk --no-cache add alpine-sdk coreutils \
+  && apk --no-cache add alpine-sdk coreutils sudo \
   && adduser -G abuild -g "Alpine Package Builder" -s /bin/ash -D builder \
   && echo "builder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
   && mkdir /packages \


### PR DESCRIPTION
💁 As of Alpine Linux 3.12, the `sudo` package isn't installed by default. These changes ensure the package is available.