### PR TITLE
Alpine 3.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.15
 RUN apk --no-cache add alpine-sdk coreutils cmake sudo \
   && adduser -G abuild -g "Alpine Package Builder" -s /bin/ash -D builder \
   && echo "builder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \


### PR DESCRIPTION
💁 Version 3.15 of Alpine Linux was [released on 2021-11-24](https://alpinelinux.org/posts/Alpine-3.15.0-released.html).