### PR TITLE
Actions: Support Alpine Linux version schema

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,7 +3,7 @@ name: Docker push
 on:
   push:
     branches: [ "main" ]
-    tags: [ '*.*.*' ]
+    tags: [ '*.*', '*.*.*' ]
 
 env:
   REGISTRY: docker.io


### PR DESCRIPTION
💁 Alpine Linux commonly uses two slightly different version schemas:
* Major and minor
* Major, minor and patch

We use the former for tagging images and this change enables that support.